### PR TITLE
Fixed movegen bug in gen_legal_captures, and make_move bug

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -372,9 +372,30 @@ void make_move(Move move) {
 
     if (victim != '-') {
         reset_halfmove = true;
-        uint64_t* victim_bb = get_bitboard(victim);
+        uint64_t *victim_bb = get_bitboard(victim);
         clear_bit(victim_bb, to);
-        board.zobrist ^= ZOBRIST_VALUES[64*parse_piece(victim) + to];
+        board.zobrist ^= ZOBRIST_VALUES[64 * parse_piece(victim) + to];
+        if (board.w_kingside_castling_rights) {
+            if (to == H1) {
+                board.w_kingside_castling_rights = false;
+                board.zobrist ^= ZOBRIST_VALUES[769];
+            }
+        } else if (board.w_queenside_castling_rights) {
+            if (to == A1) {
+                board.w_queenside_castling_rights = false;
+                board.zobrist ^= ZOBRIST_VALUES[770];
+            }
+        } else if (board.b_queenside_castling_rights) {
+            if (to == A8) {
+                board.b_queenside_castling_rights = false;
+                board.zobrist ^= ZOBRIST_VALUES[771];
+            }
+        } else if (board.b_kingside_castling_rights) {
+            if (to == H8) {
+                board.b_kingside_castling_rights = false;
+                board.zobrist ^= ZOBRIST_VALUES[772];
+            }
+        }
     }
 
     board.w_occupied = board.w_pawns | board.w_knights | board.w_bishops | board.w_rooks | board.w_queens | board.w_king;

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -541,7 +541,7 @@ int gen_legal_captures(Move* moves, bool color) {
                 moves_bb = get_queen_moves(color, from) & checkmask & pinmask & enemy_bb;
                 break;
             case 'K':
-                moves_bb = get_king_moves(color, from) & ~attackmask & enemy_bb;
+                moves_bb = get_king_moves_no_castle(color, from) & ~attackmask & enemy_bb;
                 break;
         }
 
@@ -895,6 +895,15 @@ uint64_t get_king_moves(bool color, int square) {
     } else {
         if (board.b_kingside_castling_rights) set_bit(&moves, G8);
         if (board.b_queenside_castling_rights) set_bit(&moves, C8);
+        return moves & ~board.b_occupied;
+    }
+}
+
+uint64_t get_king_moves_no_castle(bool color, int square) {
+    uint64_t moves = BB_KING_ATTACKS[square];
+    if (color == WHITE) {
+        return moves & ~board.w_occupied;
+    } else {
         return moves & ~board.b_occupied;
     }
 }

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -30,6 +30,7 @@ uint64_t get_bishop_moves(bool color, int square);
 uint64_t get_rook_moves(bool color, int square);
 uint64_t get_queen_moves(bool color, int square);
 uint64_t get_king_moves(bool color, int square);
+uint64_t get_king_moves_no_castle(bool color, int square);
 
 
 #endif


### PR DESCRIPTION
In function `void make_move(Move mv);`, added logic which removes castling rights if castling-side rook is captured.

In function `int gen_legal_captures(Move mvs[], bool color);`, removed generation of castle moves since castle legality is not checked. Causing generation of moves which ruins board state, leading to runtime crash.